### PR TITLE
DOC: Fix lhvl#DbC tag in documentation

### DIFF
--- a/doc/lh-vim-lib.txt
+++ b/doc/lh-vim-lib.txt
@@ -3633,7 +3633,7 @@ It'll return:
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-DESIGN BY CONTRACT FUNCTIONS                          *lhvl#project*    {{{2
+DESIGN BY CONTRACT FUNCTIONS                          *lhvl#DbC*    {{{2
 @since Version 4.0.0
 This set of functions introduce DbC helpers. There are here to help plugin
 developers to detect and eradicate VimL programming errors.


### PR DESCRIPTION
Seems like the "DESIGN BY CONTRACT" tag was set to lhvl#project, making :helptags complains, and really should be set to lhvl#DbC (since this is what the summary refers to).