### PR TITLE
Fix a forgotten single quotation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ See http://hermitte.free.fr/vim/general.php#expl_words_tools
     plugins that use it:
 
     ```
-    flavor LucHermitte/lh-vim-lib
+    flavor 'LucHermitte/lh-vim-lib'
     ```
 
   * Vundle/NeoBundle:


### PR DESCRIPTION
vim-flaver like a ruby script, so required single quotation.