### PR TITLE
BUG: Fix `lh#list#rotate(list, 0)`

### DIFF
--- a/autoload/lh/list.vim
+++ b/autoload/lh/list.vim
@@ -735,6 +735,9 @@ endfunction
 " Function: lh#list#rotate(list, rot) {{{3
 " {rot} must belong to [-len(list)n +len(list)]
 function! lh#list#rotate(list, rot) abort
+  if a:rot == 0
+    return a:list
+  endif
   let res = a:list[a:rot :] + a:list[: (a:rot-1)]
   return res
 endfunction


### PR DESCRIPTION
Calling rotate with `{rot} = 0` returns a concatenation of two list copies:
```viml
: echo lh#list#rotate([1, 2, 3], 0)
[1, 2, 3, 1, 2, 3]
```